### PR TITLE
Add tasks index to storage.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 """JustDoIt is a tool which help you organize your tasks in different boards."""
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Ghassen Telmoudi'
 __licence__ = 'MIT'

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ def list():  # pylint: disable=R0914,W0622
     """List all boards and tasks."""
     storage = JsonStorage(file_path=STORAGE_FILE_PATH)
     data = storage.read()
-    for board_id, board_data in data.items():
+    for board_id, board_data in data['boards'].items():
         board_suffix = get_board_suffix(board_data['tasks'])
         click.echo()
         message = f'  {board_id}. {board_data["name"]} {board_suffix}'
@@ -51,7 +51,7 @@ def list():  # pylint: disable=R0914,W0622
                 + click.style(f'{priority_icon}')
             )
     click.echo()
-    tasks = get_tasks(data)
+    tasks = get_tasks(data['boards'])
     total_number_of_tasks = len(tasks)
     total_number_of_done_tasks = get_number_of_done_tasks(tasks)
     total_number_of_tasks_in_progress = get_number_of_tasks_in_progress(tasks)

--- a/app/models.py
+++ b/app/models.py
@@ -36,8 +36,6 @@ class Board:  # pylint: disable=R0903
 class Task:  # pylint: disable=R0903
     """Task model class."""
 
-    board_id = None
-
     def __init__(  # pylint: disable=R0913
             self,
             id: str = None,  # pylint: disable=W0622

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,8 @@ else
     REQUIREMENT_FILE_PATH=requirements/common.txt
 fi
 echo "STORAGE_FILE_PATH='$STORAGE_FILE_PATH'" > "$ENV_FILE_PATH"
-echo "{}" > "$STORAGE_FILE_PATH"
+FIXTURES='{"boards":{}, "tasks_index": {}, "last_board_id": null, "last_task_id": null}'
+echo $FIXTURES > "$STORAGE_FILE_PATH"
 echo "Installing requirements"
 python3 -m pip install -r $REQUIREMENT_FILE_PATH
 echo "Installing Just Do It CLI"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='just-do-it-cli',
-    version='0.1.1',
+    version='0.1.2',
     author='Ghassen Telmoudi',
     author_email='ghassen.telmoudi@gmail.com',
     py_modules=['just_do_it_cli'],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,14 @@ from app.storage import JsonStorage
 
 def setup_function(function):
     storage = JsonStorage(file_path=STORAGE_FILE_PATH)
-    storage.write({})
+    storage.write(
+        {
+            'boards':{},
+            'tasks_index': {},
+            'last_board_id': None,
+            'last_task_id': None
+        }
+    )
 
 
 def test_create_board_command():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@ from app.helpers import (
 
 
 @pytest.mark.parametrize(
-    'task_list,expected',
+    'tasks,expected',
     [
         ({}, 0),
         ({'1': {'status': Status.IN_PROGRESS}}, 0),
@@ -42,12 +42,12 @@ from app.helpers import (
         ),
     ]
 )
-def test_get_number_of_done_tasks_returns_total_done_tasks(task_list, expected):
-    assert get_number_of_done_tasks(task_list) == expected
+def test_get_number_of_done_tasks_returns_total_done_tasks(tasks, expected):
+    assert get_number_of_done_tasks(tasks) == expected
 
 
 @pytest.mark.parametrize(
-    'task_list,expected',
+    'tasks,expected',
     [
         ({}, 0),
         ({'1': {'status': Status.DONE}}, 0),
@@ -71,12 +71,12 @@ def test_get_number_of_done_tasks_returns_total_done_tasks(task_list, expected):
         ),
     ]
 )
-def test_get_number_of_tasks_in_progress_returns_total_tasks_in_progress(task_list, expected):
-    assert get_number_of_tasks_in_progress(task_list) == expected
+def test_get_number_of_tasks_in_progress_returns_total_tasks_in_progress(tasks, expected):
+    assert get_number_of_tasks_in_progress(tasks) == expected
 
 
 @pytest.mark.parametrize(
-    'task_list,expected',
+    'tasks,expected',
     [
         ({}, '[0/0]'),
         ({'1': {'status': Status.PENDING}}, '[0/1]'),
@@ -108,8 +108,8 @@ def test_get_number_of_tasks_in_progress_returns_total_tasks_in_progress(task_li
         ),
     ]
 )
-def test_get_board_suffix(task_list, expected):
-    assert get_board_suffix(task_list) == expected
+def test_get_board_suffix(tasks, expected):
+    assert get_board_suffix(tasks) == expected
 
 
 @pytest.mark.parametrize(
@@ -155,7 +155,7 @@ def test_get_board_suffix(task_list, expected):
                     'tasks': {
                         '1': {'name': 'Task 1'},
                         '2': {'name': 'Task 2'}
-                    },
+                    }
                 },
                 '2': {
                     'name': 'Board 2',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,18 +6,22 @@ from app.models import Board, Task
 @pytest.fixture
 def storage_data():
     return {
-        '1': {
-            'name': 'Coding',
-            'tasks': {
-                '1': {
-                    'description': 'Create justdoit push command to sync local data with the API',
-                    'priority': 4,
-                    'board': '1',
-                    'status': 3
+        'boards':{
+            '1': {
+                'name': 'Coding',
+                'tasks': {
+                    '1': {
+                        'description': (
+                            'Create justdoit push command to sync local data '
+                            'with the API'
+                        ),
+                        'priority': 4,
+                        'board': '1',
+                        'status': 3
+                    }
                 }
             }
         }
-
     }
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -9,7 +9,7 @@ from app.storage import JsonStorage
 
 @pytest.fixture
 def data():
-    return {'1': {'name': 'My Board'}}
+    return {'boards':{'1': {'name': 'My Board'}}}
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def test_should_read_from_json_file_and_return_dict(file_path, data):
 
 
 def test_should_write_to_json_file_and_return(file_path):
-    data = {'1': {'name': 'My Board'}, '2': {'name': 'Meetings'}}
+    data = {'boards': {'1': {'name': 'My Board'}, '2': {'name': 'Meetings'}}}
     storage = JsonStorage(file_path=file_path)
     storage.write(data)
     assert storage.read() == data


### PR DESCRIPTION
The tasks index will make it easier have access to the tasks,
instead previously we have to go through all of them to find the board_id.
We also cache the last id for both boards and tasks, to avoid the need to
go through all of them to find the it.
There were some what a major refactoring to adapt with the new storage
structure.
The version was also updated from 0.1.1 to 0.1.2.